### PR TITLE
feat: remove display property for img

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -133,10 +133,6 @@
   display: inline;
 }
 
-img {
-  display: inline;
-}
-
 /* customize the v-clicks */
 .slidev-vclick-target {
   transition: opacity 100ms ease;


### PR DESCRIPTION
Remove the `display` property of `img` tag. While it has no effect in `example.md`, doing so allows for more flexible image arrangement, such as centering images with `class="mx-auto"`.

Resolves #18 .